### PR TITLE
:bug: #137 show correct punishments amount

### DIFF
--- a/frontend/src/components/punishments/PunishmentsListed.svelte
+++ b/frontend/src/components/punishments/PunishmentsListed.svelte
@@ -21,11 +21,13 @@
           .includes(pun.punishment_type))
       .filter((pun) => ($showPaid ? pun : pun.verified_time === null))
       .filter((pun) => (new Date(pun.created_time).getTime() >= $onlyShowAfterDate.getTime() && new Date(pun.created_time).getTime() <= $onlyShowBeforeDate.getTime()) || (new Date(pun.created_time).getDate() == $onlyShowAfterDate.getDate() && new Date(pun.created_time).getMonth() == $onlyShowAfterDate.getMonth() && new Date(pun.created_time).getFullYear() == $onlyShowAfterDate.getFullYear()) || (new Date(pun.created_time).getDate() == $onlyShowBeforeDate.getDate() && new Date(pun.created_time).getMonth() == $onlyShowBeforeDate.getMonth() && new Date(pun.created_time).getFullYear() == $onlyShowBeforeDate.getFullYear())) as punishment}
-      <img
-        class="h-8 w-8 m-[2px]"
-        alt="punishment"
-        src="{getUrl(punishment.punishment_type)}"
-      />
+      {#each Array(punishment.amount) as _, i}
+        <img
+          class="h-8 w-8 m-[2px]"
+          alt="punishment"
+          src="{getUrl(punishment.punishment_type)}"
+        />
+      {/each}
     {/each}
   {:else}
     Ingen straffer


### PR DESCRIPTION
the punishment list now shows the correct amount of punishments rather than just the count of punishments:

![0e1610378fdc3615d5ab0ec700d57edb](https://user-images.githubusercontent.com/54741019/196268099-cf3fee0e-d321-4496-b920-f76f74076bce.png)

Closes #137 