### PR TITLE
:lipstick: #162 update width for punishment icons containers

### DIFF
--- a/frontend/src/components/punishments/PunishmentInfo.svelte
+++ b/frontend/src/components/punishments/PunishmentInfo.svelte
@@ -90,7 +90,7 @@
         {/if}
       </div>
 
-      <div class="col-span-2 border-box">
+      <div class="col-span-2 border-box flex flex-col justify-center h-full">
         <p class="break-words break-spaces">{punishment.reason}</p>
         <p class="break-words break-spaces">
           {#await getUser(Number(punishment.created_by)) then user}
@@ -190,7 +190,7 @@
   }
 
   .punishment_icons {
-    @apply flex justify-center items-center col-span-4;
+    @apply flex justify-center flex-wrap items-center col-span-4 p-4;
     min-width: 7em;
     border-right: 1px solid #d9d9d9;
     height: 100%;

--- a/frontend/src/components/punishments/PunishmentsListed.svelte
+++ b/frontend/src/components/punishments/PunishmentsListed.svelte
@@ -15,7 +15,7 @@
   }
 </script>
 
-<div class="flex justify-center flex-wrap max-w-[13rem]">
+<div class="flex justify-center flex-wrap max-w-[20rem]">
   {#await row.straffer}
     <Circle size="60" color="#153E75" unit="px" duration="1s" />
   {:then}


### PR DESCRIPTION
Updated the max width of the containers with punishment icons such that they don't overflow the page width:

![image](https://user-images.githubusercontent.com/54741019/199321548-cfcd99db-a830-4210-80fd-b32143fda80f.png)

Closes #162 