### PR TITLE
:bug: #173 selected members refresh when changing groups

### DIFF
--- a/frontend/src/components/newPunishmentMultiple/PunishMultiple.svelte
+++ b/frontend/src/components/newPunishmentMultiple/PunishMultiple.svelte
@@ -1,28 +1,34 @@
 <script lang="ts">
   /* eslint-disable no-unused-vars */
-  import Svelecte, { addFormatter } from "svelecte";
-  import { User } from "../../lib/types";
-  import { filteredUsers } from "../../stores/users";
-  import AddNewPunishment from "../punishments/AddNewPunishment.svelte";
+  import Svelecte, { addFormatter } from 'svelecte'
+  import { User } from '../../lib/types'
+  import { filteredUsers } from '../../stores/users'
+  import AddNewPunishment from '../punishments/AddNewPunishment.svelte'
 
-  export let displayNewPunishment: boolean;
-  export let setDisplayNewPunishment: (display: boolean) => void;
+  export let displayNewPunishment: boolean
+  export let setDisplayNewPunishment: (display: boolean) => void
 
-  let selection: User[];
-  let value: User[];
+  let selection: User[]
+  let value: User[]
+
+  const onGroupChange = (newUsers: User[]) => {
+    value = []
+  }
+
+  $: onGroupChange($filteredUsers)
 
   const myI18n = {
     empty: `Alle brukere er allerede lagt til`,
-    nomatch: "Ingen matchende brukere",
-  };
+    nomatch: 'Ingen matchende brukere'
+  }
 
   function userRenderer(user: User) {
-    return `${user.first_name} ${user.last_name}`;
+    return `${user.first_name} ${user.last_name}`
   }
 
   addFormatter({
-    usersNames: userRenderer,
-  });
+    usersNames: userRenderer
+  })
 </script>
 
 <div class="flex flex-col ml-2 mr-2">


### PR DESCRIPTION
Members chosen to give punishment to from the PunishMultiple component now refresh when changing groups and the PunishMultiple component is still displayed:

![ezgif-3-9609497a8f](https://user-images.githubusercontent.com/54741019/199563991-7789d872-505b-4e83-ae4f-6121b6c17354.gif)

Closes #173 

