### PR TITLE
Change postgres port to unused port

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -10,27 +10,27 @@ prod: .prod-reqs
 
 dev: .dev-reqs
 	trap 'docker stop dev-db' EXIT
-	docker run -d --rm --name dev-db -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=dev -v ${PWD}/postgres-data:/var/lib/postgresql/data postgres:11.3-alpine
+	docker run -d --rm --name dev-db -p 5433:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=dev -v ${PWD}/postgres-data:/var/lib/postgresql/data postgres:11.3-alpine
 	POSTGRES_DB=dev poetry run uvicorn --reload --reload-dir app app.api.init_api:asgi_app
 
 dev-memory: .dev-reqs
 	trap 'docker stop test-db' EXIT
-	docker run -d --rm --name test-db -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=test postgres:11.3-alpine -c shared_buffers=500MB -c fsync=off
+	docker run -d --rm --name test-db -p 5433:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=test postgres:11.3-alpine -c shared_buffers=500MB -c fsync=off
 	POSTGRES_DB=test poetry run uvicorn --reload --reload-dir app app.api.init_api:asgi_app
 
 test: .dev-reqs
 	trap 'docker stop test-db' EXIT
-	docker run -d --rm --name test-db -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DEFAULT_DATABASE_NAME=db -v ${PWD}/create-databases.sh:/docker-entrypoint-initdb.d/temp.sh -v ${PWD}/tests:/tests postgres:11.3-alpine -c shared_buffers=500MB -c fsync=off
+	docker run -d --rm --name test-db -p 5433:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DEFAULT_DATABASE_NAME=db -v ${PWD}/create-databases.sh:/docker-entrypoint-initdb.d/temp.sh -v ${PWD}/tests:/tests postgres:11.3-alpine -c shared_buffers=500MB -c fsync=off
 	POSTGRES_DB=test poetry run pytest --ignore=postgres-data --asyncio-mode=strict
 
 testv: .dev-reqs
 	trap 'docker stop test-db' EXIT
-	docker run -d --rm --name test-db -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DEFAULT_DATABASE_NAME=db -v ${PWD}/create-databases.sh:/docker-entrypoint-initdb.d/temp.sh -v ${PWD}/tests:/tests postgres:11.3-alpine -c shared_buffers=500MB -c fsync=off
+	docker run -d --rm --name test-db -p 5433:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DEFAULT_DATABASE_NAME=db -v ${PWD}/create-databases.sh:/docker-entrypoint-initdb.d/temp.sh -v ${PWD}/tests:/tests postgres:11.3-alpine -c shared_buffers=500MB -c fsync=off
 	POSTGRES_DB=test poetry run pytest --ignore=postgres-data --asyncio-mode=strict -v --cov=app --cov-report term:skip-covered --cov-report html
 
 testvv: .dev-reqs
 	trap 'docker stop test-db' EXIT
-	docker run -d --rm --name test-db -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DEFAULT_DATABASE_NAME=db -v ${PWD}/create-databases.sh:/docker-entrypoint-initdb.d/temp.sh -v ${PWD}/tests:/tests postgres:11.3-alpine -c shared_buffers=500MB -c fsync=off
+	docker run -d --rm --name test-db -p 5433:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DEFAULT_DATABASE_NAME=db -v ${PWD}/create-databases.sh:/docker-entrypoint-initdb.d/temp.sh -v ${PWD}/tests:/tests postgres:11.3-alpine -c shared_buffers=500MB -c fsync=off
 	POSTGRES_DB=test poetry run pytest --ignore=postgres-data --asyncio-mode=strict -vv --cov=app --cov-report term:skip-covered --cov-report html
 
 .prod-reqs:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,7 +12,7 @@ from pydantic import BaseSettings
 class Settings(BaseSettings):
     vengeful_database: str = ":memory:"
     postgres_host: str = "127.0.0.1"
-    postgres_port: int = 5432
+    postgres_port: int = 5433
     postgres_user: str = "postgres"
     postgres_password: str = "postgres"
     postgres_db: str = "dev"


### PR DESCRIPTION
The postgres connection previously used the default port 5432. If you had postgres installed on you system, it would collide with the docker postgres containers. It now uses 5433.