### PR TITLE
Add reason_hidden field to punishment

### DIFF
--- a/backend/app/db/punishments.py
+++ b/backend/app/db/punishments.py
@@ -68,6 +68,7 @@ class Punishments:
                                                      user_id,
                                                      punishment_type_id,
                                                      reason,
+                                                     reason_hidden,
                                                      amount,
                                                      created_by,
                                                      created_at)
@@ -76,6 +77,7 @@ class Punishments:
                         p.user_id,
                         p.punishment_type_id,
                         p.reason,
+                        p.reason_hidden,
                         p.amount,
                         p.created_by,
                         p.created_at
@@ -93,6 +95,7 @@ class Punishments:
                         user_id,
                         p.punishment_type_id,
                         p.reason,
+                        p.reason_hidden,
                         p.amount,
                         created_by,
                         datetime.datetime.utcnow(),

--- a/backend/app/db/users.py
+++ b/backend/app/db/users.py
@@ -28,6 +28,7 @@ class Users:
         self,
         offset: int,
         limit: int,
+        force_include_reasons: bool = False,
         conn: Optional[Pool] = None,
     ) -> list[LeaderboardUser]:
         async with MaybeAcquire(conn, self.db.pool) as conn:
@@ -49,7 +50,15 @@ class Users:
                 limit,
             )
 
-            return [LeaderboardUser(**r) for r in res]
+            users = [LeaderboardUser(**r) for r in res]
+
+            if not force_include_reasons:
+                for user in users:
+                    for punishment in user.punishments:
+                        if punishment.reason_hidden:
+                            punishment.reason = ""
+
+            return users
 
     async def get_all_raw(
         self,

--- a/backend/app/migrations/0001_initial_schema.sql
+++ b/backend/app/migrations/0001_initial_schema.sql
@@ -39,6 +39,7 @@ CREATE TABLE IF NOT EXISTS group_punishments (
 	user_id INTEGER NOT NULL references users(user_id),
 	punishment_type_id INTEGER NOT NULL references punishment_types(punishment_type_id),
 	reason TEXT NOT NULL,
+	reason_hidden BOOLEAN DEFAULT false,
 	amount INTEGER NOT NULL,
 	-- verified_by INTEGER references users(user_id),
 	created_by INTEGER references users(user_id),

--- a/backend/app/models/punishment.py
+++ b/backend/app/models/punishment.py
@@ -12,6 +12,7 @@ from app.types import GroupId, PunishmentId, PunishmentTypeId, UserId
 class PunishmentBase(BaseModel):
     punishment_type_id: PunishmentTypeId
     reason: str
+    reason_hidden: bool
     amount: int
 
 

--- a/frontend/src/components/leaderboard/createPunishmentTableRow/CreatePunishmentTableRow.tsx
+++ b/frontend/src/components/leaderboard/createPunishmentTableRow/CreatePunishmentTableRow.tsx
@@ -1,10 +1,11 @@
-import { useMutation } from "@tanstack/react-query";
-import axios, { AxiosResponse } from "axios";
-import { useState } from "react";
-import { getAddPunishmentUrl } from "../../../helpers/api";
-import { Button } from "../../button";
 import { AlcoholInput, TextInput } from "../../input";
+import axios, { AxiosResponse } from "axios";
+
+import { Button } from "../../button";
 import { InputForm } from "./InputForm";
+import { getAddPunishmentUrl } from "../../../helpers/api";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
 
 interface CreatePunishmentTableRowProps {
   groupId: number;
@@ -19,6 +20,7 @@ export const CreatePunishmentTableRow = ({
   const [newPunishment, setNewPunishment] = useState({
     punishment_type_id: 1,
     reason: "",
+    reason_hidden: false,
     amount: 0,
   });
 

--- a/frontend/src/components/leaderboard/createPunishmentTableRow/InputForm.tsx
+++ b/frontend/src/components/leaderboard/createPunishmentTableRow/InputForm.tsx
@@ -1,17 +1,20 @@
-import { UseMutateFunction } from "@tanstack/react-query";
-import { Button } from "../../button";
 import { AlcoholInput, TextInput } from "../../input";
+
+import { Button } from "../../button";
+import { UseMutateFunction } from "@tanstack/react-query";
 
 interface InputFormProps {
   newPunishment: {
     punishment_type_id: number;
     reason: string;
+    reason_hidden: boolean;
     amount: number;
   };
   setNewPunishment: React.Dispatch<
     React.SetStateAction<{
       punishment_type_id: number;
       reason: string;
+      reason_hidden: boolean;
       amount: number;
     }>
   >;

--- a/frontend/src/helpers/types.ts
+++ b/frontend/src/helpers/types.ts
@@ -18,6 +18,7 @@ export interface LeaderboardUser {
 export interface Punishment {
   punishment_type_id: number;
   reason: string;
+  reason_hidden: boolean;
   amount: number;
   punishment_id: number;
   created_at: string;


### PR DESCRIPTION
Adds a new field `reason_hidden` that can be used to hide the reason for a given punishment. Please note that the reason will only be hidden if viewed outside the groups context. That means that reasons are always visible in the groups leaderboard, but not necessarily in the wall of shame leaderboard.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] I have run lints
