### PR TITLE
Add /user/me endpoint

### DIFF
--- a/backend/app/models/group.py
+++ b/backend/app/models/group.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel  # pylint: disable=no-name-in-module
 
 from app.models.group_user import GroupUser
 from app.models.punishment_type import PunishmentTypeRead
+from app.models.user import UserBase
 from app.types import GroupId
 
 
@@ -28,3 +29,7 @@ class Group(GroupBase):
 
 class GroupCreate(GroupBase):
     pass
+
+
+class UserWithGroups(UserBase):
+    groups: list[Group]

--- a/backend/tests/fixtures.py
+++ b/backend/tests/fixtures.py
@@ -77,6 +77,38 @@ async def mock() -> AsyncGenerator[aioresponses, None]:
             payload=ow_group_users_response,
         )
 
+        # TestOW.test_get_my_user()
+        m.get(
+            re.compile(
+                rf"{ESCAPED_BASE_OLD_ONLINE}/api/v1/group/online-groups\?members__user=\d+"
+            ),
+            status=200,
+            payload=ow_groups_for_user_response,
+        )
+        m.get(
+            re.compile(
+                rf"{ESCAPED_BASE_OLD_ONLINE}\/api\/v1\/group\/online-groups\/\d+\/group-users"
+            ),
+            status=200,
+            payload=ow_group_users_response,
+        )
+
+        # TestOW.test_get_my_user_empty_groups()
+        m.get(
+            re.compile(
+                rf"{ESCAPED_BASE_OLD_ONLINE}/api/v1/group/online-groups\?members__user=\d+"
+            ),
+            status=200,
+            payload=ow_groups_for_user_response,
+        )
+        m.get(
+            re.compile(
+                rf"{ESCAPED_BASE_OLD_ONLINE}\/api\/v1\/group\/online-groups\/\d+\/group-users"
+            ),
+            status=200,
+            payload=ow_group_users_response,
+        )
+
         # TestOW.test_get_my_groups_other_user_in_group()
         m.get(
             f"{BASE_OLD_ONLINE}/api/v1/profile",


### PR DESCRIPTION
Adds an endpoint to get information about the currently logged in user. The endpoint is `/user/me`. This includes a field `groups` and can therefore be used instead of `/group/me`. If that is not interesting then one can disable the fetching of groups using `?include_groups=false`