### PR TITLE
Fix missing user_id in /user/me

### DIFF
--- a/backend/app/models/group.py
+++ b/backend/app/models/group.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel  # pylint: disable=no-name-in-module
 
 from app.models.group_user import GroupUser
 from app.models.punishment_type import PunishmentTypeRead
-from app.models.user import UserBase
+from app.models.user import User
 from app.types import GroupId
 
 
@@ -31,5 +31,5 @@ class GroupCreate(GroupBase):
     pass
 
 
-class UserWithGroups(UserBase):
+class UserWithGroups(User):
     groups: list[Group]

--- a/backend/tests/test_ow.py
+++ b/backend/tests/test_ow.py
@@ -23,6 +23,7 @@ GROUPS_ME_RESPONSE = [
 
 USERS_ME_RESPONSE = {
     "ow_user_id": 2581,
+    "user_id": 1,
     "first_name": "Brage",
     "last_name": "",
     "email": "email1@email.com",


### PR DESCRIPTION
The field `user_id` is now correctly a part of the `/user/me` endpoint response. 