### PR TITLE
Filter reactions on groups page

### DIFF
--- a/backend/app/api/endpoints/punishment.py
+++ b/backend/app/api/endpoints/punishment.py
@@ -74,22 +74,9 @@ async def post_punishment_reaction(
 
     async with app.db.pool.acquire() as conn:
         try:
-            punishment = await app.db.punishments.get(punishment_id, conn=conn)
+            await app.db.punishments.get(punishment_id, conn=conn)
         except NotFound as exc:
             raise HTTPException(status_code=404, detail="Punishment not found") from exc
-
-        group_id = punishment.group_id
-
-        res = await app.db.groups.is_in_group(
-            user_id,
-            group_id,
-            conn=conn,
-        )
-        if not res:
-            raise HTTPException(
-                status_code=403,
-                detail="You must be a member of the group to perform this action.",
-            )
 
         if not is_emoji(punishment_reaction.emoji):
             raise HTTPException(

--- a/backend/app/db/group_members.py
+++ b/backend/app/db/group_members.py
@@ -125,10 +125,16 @@ class GroupMembers:
         conn: Optional[Pool] = None,
     ) -> list[dict[str, Any]]:
         async with MaybeAcquire(conn, self.db.pool) as conn:
-            query = """SELECT gp.*, COALESCE(json_agg(pr) FILTER (WHERE pr.punishment_reaction_id IS NOT NULL), '[]') as reactions FROM group_punishments gp
-                        LEFT JOIN punishment_reactions pr ON pr.punishment_id = gp.punishment_id
-                        WHERE group_id = $1 AND user_id = $2 AND pr.created_by IN (SELECT user_id FROM group_members WHERE group_id = $1)
-                        GROUP BY gp.punishment_id
+            query = """SELECT gp.*, COALESCE(json_agg(pr) FILTER (WHERE pr.punishment_reaction_id IS NOT NULL), '[]') as reactions
+                    FROM group_punishments gp
+                    LEFT JOIN (
+                        SELECT pr1.*
+                        FROM punishment_reactions pr1
+                        JOIN group_members gm ON pr1.created_by = gm.user_id
+                        WHERE gm.group_id = $1
+                    ) pr ON pr.punishment_id = gp.punishment_id
+                    WHERE group_id = $1 AND user_id = $2
+                    GROUP BY gp.punishment_id;
                     """
 
             punishments = []
@@ -147,8 +153,13 @@ class GroupMembers:
         async with MaybeAcquire(conn, self.db.pool) as conn:
             query = """SELECT gp.*, COALESCE(json_agg(pr) FILTER (WHERE pr.punishment_reaction_id IS NOT NULL), '[]') as reactions
                     FROM group_punishments gp
-                    LEFT JOIN punishment_reactions pr ON pr.punishment_id = gp.punishment_id
-                    WHERE group_id = $1 AND user_id = ANY($2) AND pr.created_by IN (SELECT user_id FROM group_members WHERE group_id = $1)
+                    LEFT JOIN (
+                        SELECT pr1.*
+                        FROM punishment_reactions pr1
+                        JOIN group_members gm ON pr1.created_by = gm.user_id
+                        WHERE gm.group_id = $1
+                    ) pr ON pr.punishment_id = gp.punishment_id
+                    WHERE user_id IN (SELECT unnest($2::int[]))  -- $2 should be an array of user IDs
                     GROUP BY gp.punishment_id;"""
 
             db_punishments = await conn.fetch(query, group_id, user_ids)

--- a/backend/app/db/punishments.py
+++ b/backend/app/db/punishments.py
@@ -62,22 +62,6 @@ class Punishments:
 
         return PunishmentRead(**res)
 
-    async def get_all(
-        self,
-        user_id: UserId,
-        group_id: GroupId,
-        conn: Optional[Pool] = None,
-    ) -> list[PunishmentRead]:
-        async with MaybeAcquire(conn, self.db.pool) as conn:
-            query = """SELECT gp.*, COALESCE(json_agg(pr) FILTER (WHERE pr.punishment_reaction_id IS NOT NULL), '[]') as reactions FROM group_punishments gp
-                       LEFT JOIN punishment_reactions pr ON pr.punishment_id = gp.punishment_id
-                       WHERE group_id = $1 AND user_id = $2
-                       GROUP BY gp.punishment_id"""
-
-            punishments = await conn.fetch(query, group_id, user_id)
-
-        return [PunishmentRead(**dict(x)) for x in punishments]
-
     async def insert_multiple(
         self,
         group_id: GroupId,

--- a/backend/app/db/punishments.py
+++ b/backend/app/db/punishments.py
@@ -69,7 +69,7 @@ class Punishments:
         conn: Optional[Pool] = None,
     ) -> list[PunishmentRead]:
         async with MaybeAcquire(conn, self.db.pool) as conn:
-            query = """SELECT * FROM group_punishments ELECT gp.*, COALESCE(json_agg(pr) FILTER (WHERE pr.punishment_reaction_id IS NOT NULL), '[]') as reactions FROM group_punishments gp
+            query = """SELECT gp.*, COALESCE(json_agg(pr) FILTER (WHERE pr.punishment_reaction_id IS NOT NULL), '[]') as reactions FROM group_punishments gp
                        LEFT JOIN punishment_reactions pr ON pr.punishment_id = gp.punishment_id
                        WHERE group_id = $1 AND user_id = $2
                        GROUP BY gp.punishment_id"""


### PR DESCRIPTION
GROUP CONTEXT: Reactions are now filtered to only include reactions that were given by a member of the group the punishment was given in.

GLOBAL CONTEXT: Reactions are not filtered and shows all reactions regardless of which group the giving user is related to.