### PR TITLE
fix: fetch missing group data on modal open

### DIFF
--- a/frontend/src/views/groups/tabs/modal/Modal.tsx
+++ b/frontend/src/views/groups/tabs/modal/Modal.tsx
@@ -39,7 +39,7 @@ export const Modal = forwardRef(
     const { setNotification } = useContext(NotificationContext);
 
     const { isLoading, error, data } = useQuery({
-      queryKey: ["groupLeaderboard"],
+      queryKey: ["groupLeaderboard", selectedGroup?.group_id],
       queryFn: () =>
         axios
           .get(getGroupLeaderboardUrl(selectedGroup.group_id))


### PR DESCRIPTION
Fixes the ref issue when trying to open the add punishment modal.