### PR TITLE
Fix sorting of groups and group members

### DIFF
--- a/frontend/src/views/groups/GroupsView.tsx
+++ b/frontend/src/views/groups/GroupsView.tsx
@@ -21,8 +21,8 @@ export const GroupsView = () => {
       axios.get(ME_URL).then((res: AxiosResponse<User>) => {
         const user = res.data;
         user.groups.sort((a, b) => a.name.localeCompare(b.name));
-        setUser({ user_id: res.data.user_id });
-        return res.data;
+        setUser({ user_id: user.user_id });
+        return user;
       }),
   });
 

--- a/frontend/src/views/groups/GroupsView.tsx
+++ b/frontend/src/views/groups/GroupsView.tsx
@@ -19,6 +19,8 @@ export const GroupsView = () => {
     queryKey: ["groupsData"],
     queryFn: () =>
       axios.get(ME_URL).then((res: AxiosResponse<User>) => {
+        const user = res.data;
+        user.groups.sort((a, b) => a.name.localeCompare(b.name));
         setUser({ user_id: res.data.user_id });
         return res.data;
       }),


### PR DESCRIPTION
Before this groups would shuffle randomly, this sorts it client side to ensure this doesn't happen