### PR TITLE
Fix created by name in punishments

### DIFF
--- a/backend/app/db/group_members.py
+++ b/backend/app/db/group_members.py
@@ -133,7 +133,7 @@ class GroupMembers:
                         JOIN group_members gm ON pr1.created_by = gm.user_id
                         WHERE gm.group_id = $1
                     ) pr ON pr.punishment_id = gp.punishment_id
-                    LEFT JOIN users ON gp.user_id = users.user_id
+                    LEFT JOIN users ON gp.created_by = users.user_id
                     WHERE group_id = $1 AND gp.user_id = $2
                     GROUP BY gp.punishment_id, created_by_name;
                     """
@@ -160,7 +160,7 @@ class GroupMembers:
                         JOIN group_members gm ON pr1.created_by = gm.user_id
                         WHERE gm.group_id = $1
                     ) pr ON pr.punishment_id = gp.punishment_id
-                    LEFT JOIN users ON gp.user_id = users.user_id
+                    LEFT JOIN users ON gp.created_by = users.user_id
                     WHERE gp.user_id IN (SELECT unnest($2::int[])) AND group_id = $1
                     GROUP BY gp.punishment_id, created_by_name;"""
 

--- a/backend/app/db/punishments.py
+++ b/backend/app/db/punishments.py
@@ -53,7 +53,7 @@ class Punishments:
         async with MaybeAcquire(conn, self.db.pool) as conn:
             query = """SELECT gp.*, CONCAT(users.first_name, ' ', users.last_name) AS created_by_name, COALESCE(json_agg(pr) FILTER (WHERE pr.punishment_reaction_id IS NOT NULL), '[]') as reactions FROM group_punishments gp
                        LEFT JOIN punishment_reactions pr ON pr.punishment_id = gp.punishment_id
-                       LEFT JOIN users ON gp.user_id = users.user_id
+                       LEFT JOIN users ON gp.created_by = users.user_id
                        WHERE gp.punishment_id = $1
                        GROUP BY gp.punishment_id, created_by_name;"""
             res = await conn.fetchrow(query, punishment_id)

--- a/backend/app/db/users.py
+++ b/backend/app/db/users.py
@@ -38,13 +38,14 @@ class Users:
                     WITH punishments_with_reactions AS (
                         SELECT
                             gp.*,
+                            u.first_name || ' ' || u.last_name as created_by_name,
                             array_remove(array_agg(pr.*), NULL) as reactions
                         FROM group_punishments gp
                         LEFT JOIN punishment_reactions pr
                             ON pr.punishment_id = gp.punishment_id
                         LEFT JOIN users u
                             ON u.user_id = gp.created_by
-                        GROUP BY gp.punishment_id
+                        GROUP BY gp.punishment_id, created_by_name
                     )
                     SELECT u.*,
                         COALESCE(json_agg(
@@ -57,7 +58,7 @@ class Users:
                                 'reason_hidden', pwr.reason_hidden,
                                 'amount', pwr.amount,
                                 'created_by', pwr.created_by,
-                                'created_by_name', CONCAT(u.first_name, ' ', u.last_name),
+                                'created_by_name', pwr.created_by_name,
                                 'created_at', pwr.created_at,
                                 'reactions', pwr.reactions,
                                 'punishment_type', (SELECT json_build_object(

--- a/backend/tests/test_ow.py
+++ b/backend/tests/test_ow.py
@@ -963,7 +963,7 @@ class TestWithDB_OW:
                             "amount": 1,
                             "created_by": 1,
                             "created_at": "",
-                            "created_by_name": "Anna IreneUpdated Updated",
+                            "created_by_name": "BrageUpdated Updated",
                             "punishment_id": 2,
                             "punishment_type": {
                                 "logo_url": "🍷",
@@ -980,7 +980,7 @@ class TestWithDB_OW:
                             "amount": 1,
                             "created_by": 1,
                             "created_at": "",
-                            "created_by_name": "Anna IreneUpdated Updated",
+                            "created_by_name": "BrageUpdated Updated",
                             "punishment_id": 3,
                             "punishment_type": {
                                 "logo_url": "🍷",


### PR DESCRIPTION
Created by name in a punishment just returned the name of the person with the punishment by mistake, this fixes it. 