### PR TITLE
Add builder for docker image on lambda

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,9 @@
+.gitignore
+docker-compose.*.yml
+mypy.ini
+pylintrc
+
+Dockerfile
+Makefile
+
+tests

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -56,7 +56,13 @@ docs:
 	poetry run pdoc3 --html --force .
 
 docker-build:
-	docker build -f lambda.Dockerfile --platform linux/amd64 -t vengeful-vineyard-backend:latest .
+	docker build -f lambda.Dockerfile --platform linux/amd64 -t vengeful-vineyard:latest .
+
+docker-push-dev:
+	docker tag vengeful-vineyard:latest 891459268445.dkr.ecr.eu-north-1.amazonaws.com/vengeful-vineyard-dev:latest && docker push 891459268445.dkr.ecr.eu-north-1.amazonaws.com/vengeful-vineyard-dev:latest
+
+docker-login:
+	aws ecr get-login-password --region eu-north-1 | docker login --username AWS --password-stdin 891459268445.dkr.ecr.eu-north-1.amazonaws.com
 
 help:
 	@echo "Makefile commands:"
@@ -73,5 +79,7 @@ help:
 	@echo "mypy:         Typecheck Python code"
 	@echo "hooks:        Run all commit hooks"
 	@echo "docker-build: Build docker image for AWS Lambda
+	@echo "docker-login: Log in to Amazon ECR
+	@echo "docker-push-: Push the docker image to the specified environment (dev,stg,prd)
 	@echo ""
 	@echo "clean:   Clean up Python environment"

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -64,6 +64,9 @@ docker-push-dev:
 docker-login:
 	aws ecr get-login-password --region eu-north-1 | docker login --username AWS --password-stdin 891459268445.dkr.ecr.eu-north-1.amazonaws.com
 
+lambda-update-dev:
+	aws lambda update-function-code --function-name vengeful-vineyard-dev --image-uri 891459268445.dkr.ecr.eu-north-1.amazonaws.com/vengeful-vineyard-dev:latest
+
 help:
 	@echo "Makefile commands:"
 	@echo "help:         Show this help."

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -55,19 +55,23 @@ clean:
 docs:
 	poetry run pdoc3 --html --force .
 
+docker-build:
+	docker build -f lambda.Dockerfile --platform linux/amd64 -t vengeful-vineyard-backend:latest .
+
 help:
 	@echo "Makefile commands:"
-	@echo "help:    Show this help."
+	@echo "help:         Show this help."
 	@echo ""
-	@echo "prod:    Run production server (vengeful_vineyard.db)"
-	@echo "dev:     Run development server (dev.db)"
+	@echo "prod:         Run production server (vengeful_vineyard.db)"
+	@echo "dev:          Run development server (dev.db)"
 	@echo ""
-	@echo "docs:    Create documentation"
-	@echo "test:    Run tests"
-	@echo "testv:   Run tests (verbose)"
-	@echo "testvv:  Run tests (very verbose)"
-	@echo "pylint:  Python linter to check for common mistakes"
-	@echo "mypy:    Typecheck Python code"
-	@echo "hooks:   Run all commit hooks"
+	@echo "docs:         Create documentation"
+	@echo "test:         Run tests"
+	@echo "testv:        Run tests (verbose)"
+	@echo "testvv:       Run tests (very verbose)"
+	@echo "pylint:       Python linter to check for common mistakes"
+	@echo "mypy:         Typecheck Python code"
+	@echo "hooks:        Run all commit hooks"
+	@echo "docker-build: Build docker image for AWS Lambda
 	@echo ""
 	@echo "clean:   Clean up Python environment"

--- a/backend/lambda.Dockerfile
+++ b/backend/lambda.Dockerfile
@@ -1,0 +1,20 @@
+FROM public.ecr.aws/lambda/python:3.11
+
+WORKDIR ${LAMBDA_TASK_ROOT}
+
+COPY pyproject.toml poetry.lock ${LAMBDA_TASK_ROOT}/
+
+RUN yum install -y gcc
+
+RUN pip install poetry==1.6.1
+
+ENV POETRY_NO_INTERACTION=1 \
+    POETRY_CACHE_DIR=/tmp/poetry_cache
+
+RUN poetry config virtualenvs.create false --local
+RUN poetry install --only main --no-interaction --no-ansi
+
+COPY app ${LAMBDA_TASK_ROOT}/app
+COPY lambda.py ${LAMBDA_TASK_ROOT}/
+
+CMD ["lambda.handler"]

--- a/backend/lambda.py
+++ b/backend/lambda.py
@@ -1,4 +1,4 @@
 from mangum import Mangum
 from app.api.init_api import asgi_app
 
-handler = Mangum(asgi_app, lifespan="off")
+handler = Mangum(asgi_app, lifespan="auto", api_gateway_base_path="/api")

--- a/backend/lambda.py
+++ b/backend/lambda.py
@@ -1,0 +1,4 @@
+from mangum import Mangum
+from app.api.init_api import asgi_app
+
+handler = Mangum(asgi_app, lifespan="off")

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -876,6 +876,20 @@ lingua = ["lingua"]
 testing = ["pytest"]
 
 [[package]]
+name = "mangum"
+version = "0.17.0"
+description = "AWS Lambda support for ASGI applications"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mangum-0.17.0-py3-none-any.whl", hash = "sha256:f00be705605bc4793958df62e4d249abf58d254c39d90bb410d069570206f4a2"},
+    {file = "mangum-0.17.0.tar.gz", hash = "sha256:5b4e26375e12eed051687670466d17968f8b74beecaca432edd4eb4127f78509"},
+]
+
+[package.dependencies]
+typing-extensions = "*"
+
+[[package]]
 name = "markdown"
 version = "3.5"
 description = "Python implementation of John Gruber's Markdown."
@@ -1761,4 +1775,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "d98e2e0b4e63028c63cbfa29f4f9bdc39f261e32dc44b5faaa89cb2c77fb7a54"
+content-hash = "8bc5c2527c8685f3caeada292641111327393aee3f45a39122a4a6aded518124"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,7 @@ fastapi = "^0.86.0"
 pyyaml = ">=6.0.1"
 emoji = "^2.8.0"
 types-emoji = "^2.1.0.3"
+mangum = "^0.17.0"
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"


### PR DESCRIPTION
Deploys the ASGI app with https://mangum.io/

## Backend Deployment Instructions

- Install AWS CLI and log in (`aws configure`)
- Install Docker engine
- `make docker-login` Log in to the private Amazon ECR repository
- `make docker-build` Build the docker image from local code
- `make docker-push-dev` Push the newly created docker image to Amazon ECR
- `make lambda-update-dev` Inform lambda to fetch the new version of the image from ECR

## Frontend Deployment Instructions

- `pnpm build` Build Vite export
- `aws s3 rm s3://dev.redwine-static.online.ntnu.no/ --recursive` Empty S3 bucket
- `aws s3 cp dist s3://dev.redwine-static.online.ntnu.no/ --recursive` Upload new dist

## Other

Changed the database migration lock from database setting parameters to a simple table

See https://github.com/dotkom/monoweb/pull/662