### PR TITLE
Add optimistic updates to /user/me endpoint

### DIFF
--- a/backend/app/api/endpoints/group.py
+++ b/backend/app/api/endpoints/group.py
@@ -41,7 +41,7 @@ router = APIRouter(
 async def get_my_groups(
     request: Request,
     wait_for_updates: bool = Query(title="Wait for updates", default=True),
-    use_cache: bool = Query(title="Use cache", default=True),
+    optimistic: bool = Query(title="Optimistic", default=False),
 ) -> list[Group]:
     app = request.app
     access_token = request.raise_if_missing_authorization()
@@ -54,12 +54,12 @@ async def get_my_groups(
     except NotFound as exc:
         raise HTTPException(status_code=401, detail="Invalid access token") from exc
 
-    await app.ow_sync.sync_for_user(
-        ow_user_id,
-        user_id,
-        wait_for_updates=wait_for_updates,
-        use_cache=use_cache,
-    )
+    if not optimistic:
+        await app.ow_sync.sync_for_user(
+            ow_user_id,
+            user_id,
+            wait_for_updates=wait_for_updates,
+        )
 
     groups = await app.db.users.get_groups(user_id)
     return groups

--- a/backend/app/api/endpoints/user.py
+++ b/backend/app/api/endpoints/user.py
@@ -29,7 +29,7 @@ async def get_me(
     request: Request,
     include_groups: bool = Query(title="Include groups", default=True),
     wait_for_updates: bool = Query(title="Wait for updates", default=True),
-    use_cache: bool = Query(title="Use cache", default=True),
+    optimistic: bool = Query(title="Optimistic", default=False),
 ) -> UserWithGroups:
     app = request.app
     access_token = request.raise_if_missing_authorization()
@@ -42,12 +42,12 @@ async def get_me(
     except NotFound as exc:
         raise HTTPException(status_code=401, detail="Invalid access token") from exc
 
-    await app.ow_sync.sync_for_user(
-        ow_user_id,
-        user_id,
-        wait_for_updates=wait_for_updates,
-        use_cache=use_cache,
-    )
+    if not optimistic:
+        await app.ow_sync.sync_for_user(
+            ow_user_id,
+            user_id,
+            wait_for_updates=wait_for_updates,
+        )
 
     async with app.db.pool.acquire() as conn:
         groups = []

--- a/backend/app/sync.py
+++ b/backend/app/sync.py
@@ -23,7 +23,6 @@ IGNORE_OW_GROUPS = (12,)  # "Komiteer"
 class OWSync:
     def __init__(self, app: "FastAPI"):
         self.app = app
-        self.last_user_sync: dict[OWUserId, float] = {}
 
     async def sync_for_access_token(
         self,
@@ -63,13 +62,7 @@ class OWSync:
         ow_user_id: OWUserId,
         user_id: UserId,
         wait_for_updates: bool = True,
-        use_cache: bool = True,
     ) -> None:
-        if self.last_user_sync.get(ow_user_id, 0) > time.time() - 60 and use_cache:
-            return
-
-        self.last_user_sync[ow_user_id] = time.time()
-
         groups_data = await self.app.http.get_ow_groups_by_user_id(ow_user_id)
         filtered_groups_data = [
             g for g in groups_data["results"] if g["id"] not in IGNORE_OW_GROUPS

--- a/backend/tests/test_ow.py
+++ b/backend/tests/test_ow.py
@@ -323,7 +323,7 @@ OTHER_USER_NOT_IN_GROUP_AUTHORIZATION = f"Bearer {OTHER_USER_NOT_IN_GROUP_ACCESS
 class TestWithDB_OW:
     @pytest.mark.asyncio
     async def test_get_my_groups_missing_authorization(self, client: Any) -> None:
-        response = await client.get("/group/me?use_cache=false")
+        response = await client.get("/group/me")
         assert response.status_code == 403 and response.json() == {
             "detail": "Not authenticated"
         }
@@ -332,7 +332,7 @@ class TestWithDB_OW:
     @pytest.mark.asyncio
     async def test_get_my_groups_unauthenticated(self, client: Any, mock: Any) -> None:
         response = await client.get(
-            "/group/me?use_cache=false", headers={"Authorization": "Bearer InvalidAuth"}
+            "/group/me", headers={"Authorization": "Bearer InvalidAuth"}
         )
         assert response.status_code == 401 and response.json() == {
             "detail": "Invalid access token"
@@ -345,7 +345,7 @@ class TestWithDB_OW:
         mock: Any,
     ) -> None:
         response = await client.get(
-            "/group/me?use_cache=false",
+            "/group/me",
             headers={"Authorization": SELF_USER_AUTHORIZATION},
         )
 
@@ -361,7 +361,7 @@ class TestWithDB_OW:
         mock: Any,
     ) -> None:
         response = await client.get(
-            "/user/me?use_cache=false",
+            "/user/me",
             headers={"Authorization": SELF_USER_AUTHORIZATION},
         )
 
@@ -377,7 +377,7 @@ class TestWithDB_OW:
         mock: Any,
     ) -> None:
         response = await client.get(
-            "/user/me?include_groups=false&use_cache=false",
+            "/user/me?include_groups=false",
             headers={"Authorization": SELF_USER_AUTHORIZATION},
         )
 
@@ -393,7 +393,7 @@ class TestWithDB_OW:
         mock: Any,
     ) -> None:
         response = await client.get(
-            "/group/me?use_cache=false",
+            "/group/me",
             headers={"Authorization": OTHER_USER_AUTHORIZATION},
         )
 
@@ -415,7 +415,7 @@ class TestWithDB_OW:
     @pytest.mark.asyncio
     async def test_get_my_groups_update(self, client: Any) -> None:
         response = await client.get(
-            "/group/me?use_cache=false",
+            "/group/me",
             headers={"Authorization": SELF_USER_AUTHORIZATION},
         )
 
@@ -450,7 +450,7 @@ class TestWithDB_OW:
         mock: Any,
     ) -> None:
         response = await client.get(
-            "/group/me?use_cache=false",
+            "/group/me",
             headers={"Authorization": OTHER_USER_NOT_IN_GROUP_AUTHORIZATION},
         )
 

--- a/frontend/src/helpers/api.ts
+++ b/frontend/src/helpers/api.ts
@@ -4,7 +4,7 @@ export const getGroupLeaderboardUrl = (groupId: number) => BASE_URL + `/group/${
 
 export const LEADERBOARD_URL = BASE_URL + "/user/leaderboard"
 
-export const ME_URL = BASE_URL + "/user/me"
+export const getMeUrl = (optimistic: boolean) => BASE_URL + `/user/me?optimistic=${optimistic}`
 
 export const GROUPS_URL = BASE_URL + "/group/me"
 

--- a/frontend/src/helpers/optimisticQuery.ts
+++ b/frontend/src/helpers/optimisticQuery.ts
@@ -1,0 +1,36 @@
+import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from "@tanstack/react-query"
+
+type QueryFn<T> = (key: QueryKey, optimistic: boolean) => Promise<T>
+type OptimisticQueryResult<T> = Omit<UseQueryResult<T, unknown>, "data"> & { data: T | undefined }
+
+export function useOptimisticQuery<T>(
+  queryKey: QueryKey,
+  queryFn: QueryFn<T>,
+  options?: UseQueryOptions<T, unknown, T, [QueryKey, boolean]>
+): OptimisticQueryResult<T> {
+  const optimisticResult = useQuery<T, unknown, T, [QueryKey, boolean]>(
+    [queryKey, true],
+    (...args) => queryFn(args, true), // spread the args and pass to queryFn
+    {
+      ...options,
+      retry: 0,
+      staleTime: Infinity,
+    }
+  )
+
+  const standardResult = useQuery<T, unknown, T, [QueryKey, boolean]>(
+    [queryKey, false],
+    (...args) => queryFn(args, false), // spread the args and pass to queryFn
+    {
+      ...options,
+      enabled: optimisticResult.isFetched,
+    }
+  )
+
+  const data = standardResult.isSuccess ? standardResult.data : optimisticResult.data
+
+  return {
+    ...standardResult,
+    data: data,
+  }
+}


### PR DESCRIPTION
This makes loading of home page drastically faster by loading the page twice at the same time, one optimistic and one not, which means one syncs with OW and one does not. The optimistic one finishes first, but when the non-optimistic one loads it replaces the result of the optimistic one.

I also removed use_cache because this is probably a better solution. 