### PR TITLE
Restricted statistics page access to users in owgroup

### DIFF
--- a/backend/app/api/endpoints/statistics.py
+++ b/backend/app/api/endpoints/statistics.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from app.api import APIRoute, Request
 
 router = APIRouter(
@@ -17,7 +17,7 @@ async def get_group_statistics(
     user_id, _ = await app.ow_sync.sync_for_access_token(access_token)
 
     async with app.db.pool.acquire() as conn:
-        is_in_any_ow_group = app.db.groups.is_in_any_ow_group(user_id, conn=conn)
+        is_in_any_ow_group = await app.db.groups.is_in_any_ow_group(user_id, conn=conn)
         if not is_in_any_ow_group:
             raise HTTPException(
                 status_code=403, detail="Du har ikke tilgang til denne ressursen"

--- a/backend/app/api/endpoints/statistics.py
+++ b/backend/app/api/endpoints/statistics.py
@@ -11,8 +11,18 @@ router = APIRouter(
 async def get_group_statistics(
     request: Request
 ):
+    access_token = request.raise_if_missing_authorization()
+
     app = request.app
+    user_id, _ = await app.ow_sync.sync_for_access_token(access_token)
+
     async with app.db.pool.acquire() as conn:
+        is_in_any_ow_group = app.db.groups.is_in_any_ow_group(user_id, conn=conn)
+        if not is_in_any_ow_group:
+            raise HTTPException(
+                status_code=403, detail="Du har ikke tilgang til denne ressursen"
+            )
+
         return await app.db.statistics.get_all_group_statistics(conn=conn)
 
 @router.get("/groups/{group_id}")

--- a/frontend/src/components/committees/CommitteeList.tsx
+++ b/frontend/src/components/committees/CommitteeList.tsx
@@ -1,9 +1,11 @@
 import { CommitteeCard } from "./CommitteeCard"
+import { useAuth } from "react-oidc-context"
 import { useCommittees } from "../../helpers/api"
 import { GroupStatistics } from "../../helpers/types"
 
 export const CommitteeList = () => {
-  const { data: groupsStatistics } = useCommittees()
+  const auth = useAuth()
+  const { data: groupsStatistics } = useCommittees({ enabled: auth.isAuthenticated })
 
   const filteredGroupsStatistics = groupsStatistics?.filter(
     (groupStatistic) => groupStatistic.group_image && groupStatistic.group_image != "NoImage"

--- a/frontend/src/components/nav/Nav.tsx
+++ b/frontend/src/components/nav/Nav.tsx
@@ -62,7 +62,8 @@ export const Nav = ({ auth }: NavProps) => {
     {
       label: "Statistikk",
       url: "/committees",
-      isActivePredicate: (item, currentLocation) => currentLocation.toLowerCase().startsWith(`${item.url}`)
+      isActivePredicate: (item, currentLocation) => currentLocation.toLowerCase().startsWith(`${item.url}`),
+      shouldShowPredicate: () => isInAnyOWGroup,
     },
   ]
 

--- a/frontend/src/helpers/api.ts
+++ b/frontend/src/helpers/api.ts
@@ -105,13 +105,14 @@ export const useMyGroups = (options?: UseQueryOptions<MeUser, unknown, MeUser, [
     options
   )
 
-export const useCommittees = () =>
+export const useCommittees = (options?: UseQueryOptions<GroupStatistics[], unknown, GroupStatistics[], [QueryKey, boolean]>) =>
   useOptimisticQuery<GroupStatistics[]>(
     ["committeesData"],
     (_, optimistic: boolean) =>
       axios.get(getGroupStatisticsUrl()).then((res: AxiosResponse<GroupStatistics[]>) => {
         return Array.isArray(res.data) ? res.data : [res.data]
-      })
+      }),
+      options
   )
 
 export const addPunishment = (groupId: string, userId: string, punishment: PunishmentCreate) => {


### PR DESCRIPTION
Only logged in users connected to a ow group can see data the statistics page

DOT-554 https://linear.app/dotkom/issue/DOT-554/only-show-statistics-page-to-users-in-committees