### PR TITLE
Use email as displayname for new users that are lacking first and last name

### DIFF
--- a/frontend/src/components/groupusertable/GroupUserTableItem.tsx
+++ b/frontend/src/components/groupusertable/GroupUserTableItem.tsx
@@ -79,6 +79,8 @@ export const GroupUserTableItem = ({ groupUser, groupData, punishmentTypes, data
 
   const punishments = groupUser.punishments.filter((punishment) => !punishment.paid || isToggled)
 
+  const displayName = groupUser.first_name && groupUser.last_name ? `${groupUser.first_name} ${groupUser.last_name}` : groupUser.email
+
   return (
     <AccordionItem value={groupUser.user_id}>
       <AccordionTrigger className="relative flex cursor-pointer justify-between gap-x-6 py-5 rounded-lg md:rounded-xl hover:bg-gray-50">
@@ -94,9 +96,9 @@ export const GroupUserTableItem = ({ groupUser, groupData, punishmentTypes, data
           <div className="flex flex-col text-left">
             <p
               className="w-32 md:w-44 overflow-hidden text-ellipsis whitespace-nowrap text-left text-xs md:text-sm font-semibold leading-6 text-gray-900 dark:text-gray-200"
-              title={`${groupUser.first_name} ${groupUser.last_name}`}
+              title={displayName}
             >
-              {groupUser.first_name} {groupUser.last_name}
+              {displayName}
             </p>
             <span className="text-gray-700 text-xs">{unpaidPunishmentsValue}kr</span>
           </div>
@@ -140,7 +142,7 @@ export const GroupUserTableItem = ({ groupUser, groupData, punishmentTypes, data
           <div className="absolute right-12 cursor-default inline-block">
             <span
               className="text-lg"
-              title={`${groupUser.first_name} ${groupUser.last_name} har fått straffer ${streak} uker på rad`}
+              title={`${displayName} har fått straffer ${streak} uker på rad`}
             >
               {streak} 🔥
             </span>

--- a/frontend/src/components/leaderboardtable/LeaderboardTableItem.tsx
+++ b/frontend/src/components/leaderboardtable/LeaderboardTableItem.tsx
@@ -45,6 +45,8 @@ export const LeaderboardTableItem = ({ leaderboardUser, dataRefetch, i }: TableI
   const today = new Date().getTime()
   const streak = weeklyStreak(today, dateToNumber)
 
+  const displayName = leaderboardUser.first_name && leaderboardUser.last_name ? `${leaderboardUser.first_name} ${leaderboardUser.last_name}` : leaderboardUser.email
+
   return (
     <AccordionItem value={leaderboardUser.user_id}>
       <AccordionTrigger className="relative flex cursor-pointer justify-between gap-x-6 py-5 rounded-lg md:rounded-xl hover:bg-gray-50">
@@ -58,14 +60,14 @@ export const LeaderboardTableItem = ({ leaderboardUser, dataRefetch, i }: TableI
                 : i + 1 === 3
                 ? "🥉"
                 : i + 1
-              : textToEmoji(leaderboardUser.first_name + leaderboardUser.last_name)}
+              : textToEmoji(displayName)}
           </span>
           <div className="flex flex-col text-left">
             <p
               className="w-32 md:w-44 overflow-hidden text-ellipsis whitespace-nowrap text-left text-xs md:text-sm font-semibold leading-6 text-gray-900 dark:text-gray-200"
-              title={`${leaderboardUser.first_name} ${leaderboardUser.last_name}`}
+              title={displayName}
             >
-              {leaderboardUser.first_name} {leaderboardUser.last_name}
+              {displayName}
             </p>
             <span className="text-gray-700 text-xs">{totalPunishmentValue}kr</span>
           </div>
@@ -105,7 +107,7 @@ export const LeaderboardTableItem = ({ leaderboardUser, dataRefetch, i }: TableI
           <div className="absolute right-12 cursor-default inline-block">
             <span
               className="text-lg"
-              title={`${leaderboardUser.first_name} ${leaderboardUser.last_name} har fått straffer ${streak} uker på rad`}
+              title={`${displayName} har fått straffer ${streak} uker på rad`}
             >
               {streak} 🔥
             </span>


### PR DESCRIPTION
I hope `email` is getting set on sign up? When you sign up as a new user on OW thorugh auth0 now, first and last name are not gathered, and you can't even set it manually in auth0 dashboard afaik.

It is much better to show the email for now until the first name and last name are gathered. Right now it is useless to use with new users.

This PR uses email if last_name and first_name are not set.

NB:

`""` is falsy in javascript, so the check is fine.

![image](https://github.com/dotkom/vengeful-vineyard/assets/55615149/7e4814a0-dca7-42a4-b053-9881fe6b8d51)
