### PR TITLE
Fix wall of shame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ dist-ssr
 
 tmpMock.ts
 .python-version
+.env

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -28,7 +28,7 @@ __all__ = (
 
 
 oidc = OpenIdConnect(
-    openIdConnectUrl="https://old.online.ntnu.no/openid/.well-known/openid-configuration",
+    openIdConnectUrl="https://auth.online.ntnu.no/openid/.well-known/openid-configuration",
 )
 
 

--- a/backend/app/api/init_api.py
+++ b/backend/app/api/init_api.py
@@ -111,7 +111,7 @@ def init_events(app: FastAPI, **db_settings: str) -> None:
 
 def init_api(**db_settings: str) -> FastAPI:
     oauth = {
-        "clientId": os.environ["AUTH0_CLIENT_ID"],
+        "clientId": "5rOMfB8Ztegz",
         "appName": "Vengeful Vineyard Docs",
         "usePkceWithAuthorizationCodeGrant": True,
         "scopes": "openid email profile onlineweb4",

--- a/backend/app/api/init_api.py
+++ b/backend/app/api/init_api.py
@@ -111,7 +111,7 @@ def init_events(app: FastAPI, **db_settings: str) -> None:
 
 def init_api(**db_settings: str) -> FastAPI:
     oauth = {
-        "clientId": "219919",
+        "clientId": os.environ["AUTH0_CLIENT_ID"],
         "appName": "Vengeful Vineyard Docs",
         "usePkceWithAuthorizationCodeGrant": True,
         "scopes": "openid email profile onlineweb4",
@@ -121,10 +121,6 @@ def init_api(**db_settings: str) -> FastAPI:
         swagger_ui_init_oauth=oauth,
         swagger_ui_oauth2_redirect_url="/docs/oauth2-redirect",
     )
-
-    @app.get("/crash")
-    async def crash():
-        raise Exception("wow i crashed")
 
     app.openapi_version = "3.0.0"
     app.router.route_class = APIRoute

--- a/backend/app/db/groups.py
+++ b/backend/app/db/groups.py
@@ -314,6 +314,7 @@ class Groups:
                     FROM
                         unnest($1::group_members[]) as m
                     )
+                    ON CONFLICT (group_id, user_id) DO NOTHING
                     RETURNING *
                     """
 

--- a/backend/app/db/users.py
+++ b/backend/app/db/users.py
@@ -346,7 +346,7 @@ class Users:
 
             result = await conn.fetch(query, user_id)
             return [Group(**row) for row in result]
-        
+
     async def get_minified_leaderboard(
         self,
         offset: int,
@@ -355,11 +355,11 @@ class Users:
     ) -> list[MinifiedLeaderboardUser]:
         async with MaybeAcquire(conn, self.db.pool) as conn:
             query = """
-            SELECT 
-                DISTINCT u.user_id, 
-                u.first_name, 
-                u.last_name, 
-                u.email, 
+            SELECT
+                DISTINCT u.user_id,
+                u.first_name,
+                u.last_name,
+                u.email,
                 u.ow_user_id,
                 COALESCE(p.total_value, 0) AS total_value,
                 COALESCE(p.emojis, '') AS emojis,
@@ -367,7 +367,7 @@ class Users:
                 COALESCE(p.amount_unique_punishments, 0) AS amount_unique_punishments
             FROM users u
             LEFT JOIN (
-                SELECT 
+                SELECT
                     p.user_id,
                     SUM(pt.value * p.amount) AS total_value,
                     STRING_AGG(REPEAT(pt.emoji, p.amount), '') AS emojis,
@@ -405,7 +405,7 @@ class Users:
     ) -> list[LeaderboardPunishmentRead]:
         async with MaybeAcquire(conn, self.db.pool) as conn:
             query = """
-            SELECT 
+            SELECT
                 gp.*,
                 CONCAT(COALESCE(NULLIF(users.first_name, ''), users.email), ' ', users.last_name) AS created_by_name,
                 COALESCE(json_agg(pr) FILTER (WHERE pr.punishment_reaction_id IS NOT NULL), '[]') as reactions,
@@ -425,6 +425,7 @@ class Users:
                 SELECT pr1.*
                 FROM punishment_reactions pr1
                 JOIN group_members gm ON pr1.created_by = gm.user_id
+                GROUP BY pr1.punishment_reaction_id
             ) pr ON pr.punishment_id = gp.punishment_id
             LEFT JOIN users ON gp.created_by = users.user_id
             WHERE gp.user_id = $1
@@ -435,5 +436,5 @@ class Users:
                 query,
                 user_id,
             )
-        
+
         return [LeaderboardPunishmentRead(**r) for r in res]

--- a/backend/app/db/users.py
+++ b/backend/app/db/users.py
@@ -5,7 +5,8 @@ from asyncpg.exceptions import UniqueViolationError
 
 from app.exceptions import DatabaseIntegrityException, NotFound
 from app.models.group import Group
-from app.models.user import LeaderboardUser, User, UserCreate, UserUpdate
+from app.models.user import LeaderboardUser, MinifiedLeaderboardUser, User, UserCreate, UserUpdate
+from app.models.punishment import LeaderboardPunishmentRead
 from app.types import InsertOrUpdateUser, OWUserId, UserId
 from app.utils.db import MaybeAcquire
 
@@ -43,93 +44,6 @@ class Users:
             )
             assert isinstance(res, int)
             return res
-
-    async def get_leaderboard(
-        self,
-        offset: int,
-        limit: int,
-        force_include_reasons: bool = False,
-        conn: Optional[Pool] = None,
-    ) -> list[LeaderboardUser]:
-        async with MaybeAcquire(conn, self.db.pool) as conn:
-            query = """
-                    WITH punishments_with_reactions AS (
-                        SELECT
-                            gp.*,
-                            COALESCE(NULLIF(u.first_name, ''), u.email) || ' ' || u.last_name as created_by_name,
-                            COALESCE(json_agg(json_build_object(
-                                'punishment_reaction_id', pr.punishment_reaction_id,
-                                'punishment_id', pr.punishment_id,
-                                'emoji', pr.emoji,
-                                'created_at', pr.created_at,
-                                'created_by', pr.created_by,
-                                'created_by_name', (SELECT COALESCE(NULLIF(first_name, ''), email) || ' ' || last_name FROM users WHERE user_id = pr.created_by)
-                            )) FILTER (WHERE pr.punishment_reaction_id IS NOT NULL), '[]') as reactions
-                        FROM group_punishments gp
-                        LEFT JOIN punishment_reactions pr
-                            ON pr.punishment_id = gp.punishment_id
-                        LEFT JOIN users u
-                            ON u.user_id = gp.created_by
-                        LEFT JOIN groups g
-                            ON g.group_id = gp.group_id
-                        WHERE g.ow_group_id IS NOT NULL OR special
-                        GROUP BY gp.punishment_id, created_by_name
-                    )
-                    SELECT u.*,
-                        COALESCE(json_agg(
-                            json_build_object(
-                                'punishment_id', pwr.punishment_id,
-                                'user_id', pwr.user_id,
-                                'punishment_type_id', pwr.punishment_type_id,
-                                'reason', pwr.reason,
-                                'reason_hidden', pwr.reason_hidden,
-                                'amount', pwr.amount,
-                                'created_by', pwr.created_by,
-                                'created_by_name', pwr.created_by_name,
-                                'created_at', pwr.created_at,
-                                'group_id', pwr.group_id,
-                                'paid', pwr.paid,
-                                'paid_at', pwr.paid_at,
-                                'marked_paid_by', pwr.marked_paid_by,
-                                'reactions', pwr.reactions,
-                                'punishment_type', (SELECT json_build_object(
-                                    'punishment_type_id', pt.punishment_type_id,
-                                    'name', pt.name,
-                                    'value', pt.value,
-                                    'emoji', pt.emoji,
-                                    'created_at', pt.created_at,
-                                    'created_by', pt.created_by,
-                                    'updated_at', pt.updated_at
-                                ) FROM punishment_types pt WHERE pt.punishment_type_id = pwr.punishment_type_id)
-                            )
-                        ) FILTER (WHERE pwr.punishment_id IS NOT NULL), '[]') AS punishments,
-                        COALESCE(SUM(pwr.amount * pt.value), 0) as total_value
-                    FROM users u
-                    LEFT JOIN punishments_with_reactions pwr
-                        ON pwr.user_id = u.user_id
-                    LEFT JOIN punishment_types pt
-                        ON pt.punishment_type_id = pwr.punishment_type_id
-                    INNER JOIN groups g
-                        ON g.group_id = pwr.group_id AND g.ow_group_id IS NOT NULL OR special
-                    GROUP BY u.user_id
-                    ORDER BY total_value DESC, u.first_name ASC
-                    OFFSET $1
-                    LIMIT $2"""
-            res = await conn.fetch(
-                query,
-                offset,
-                limit,
-            )
-
-            users = [LeaderboardUser(**r) for r in res]
-
-            if not force_include_reasons:
-                for user in users:
-                    for punishment in user.punishments:
-                        if punishment.reason_hidden:
-                            punishment.reason = ""
-
-            return users
 
     async def get_all_raw(
         self,
@@ -432,3 +346,94 @@ class Users:
 
             result = await conn.fetch(query, user_id)
             return [Group(**row) for row in result]
+        
+    async def get_minified_leaderboard(
+        self,
+        offset: int,
+        limit: int,
+        conn: Optional[Pool] = None,
+    ) -> list[MinifiedLeaderboardUser]:
+        async with MaybeAcquire(conn, self.db.pool) as conn:
+            query = """
+            SELECT 
+                DISTINCT u.user_id, 
+                u.first_name, 
+                u.last_name, 
+                u.email, 
+                u.ow_user_id,
+                COALESCE(p.total_value, 0) AS total_value,
+                COALESCE(p.emojis, '') AS emojis,
+                COALESCE(p.amount_punishments, 0) AS amount_punishments,
+                COALESCE(p.amount_unique_punishments, 0) AS amount_unique_punishments
+            FROM users u
+            LEFT JOIN (
+                SELECT 
+                    p.user_id,
+                    SUM(pt.value * p.amount) AS total_value,
+                    STRING_AGG(REPEAT(pt.emoji, p.amount), '') AS emojis,
+                    SUM(p.amount) AS amount_punishments,
+                    COUNT(DISTINCT p.punishment_type_id) AS amount_unique_punishments
+                FROM group_punishments p
+                LEFT JOIN punishment_types pt
+                    ON pt.punishment_type_id = p.punishment_type_id
+                LEFT JOIN groups g
+                    ON g.group_id = p.group_id
+                WHERE g.ow_group_id IS NOT NULL
+                GROUP BY p.user_id
+            ) p ON p.user_id = u.user_id
+            LEFT JOIN group_members gm
+                ON gm.user_id = u.user_id
+            LEFT JOIN groups g
+                ON g.group_id = gm.group_id
+            WHERE g.ow_group_id IS NOT NULL OR g.special
+            ORDER BY total_value DESC, u.first_name ASC
+            OFFSET $1
+            LIMIT $2
+            """
+            res = await conn.fetch(
+                query,
+                offset,
+                limit,
+            )
+
+        return [MinifiedLeaderboardUser(**r) for r in res]
+
+    async def get_punishments_for_leaderboard_user(
+        self,
+        user_id: UserId,
+        conn: Optional[Pool] = None,
+    ) -> list[LeaderboardPunishmentRead]:
+        async with MaybeAcquire(conn, self.db.pool) as conn:
+            query = """
+            SELECT 
+                gp.*,
+                CONCAT(COALESCE(NULLIF(users.first_name, ''), users.email), ' ', users.last_name) AS created_by_name,
+                COALESCE(json_agg(pr) FILTER (WHERE pr.punishment_reaction_id IS NOT NULL), '[]') as reactions,
+                json_build_object(
+                    'punishment_type_id', pt.punishment_type_id,
+                    'name', pt.name,
+                    'value', pt.value,
+                    'emoji', pt.emoji,
+                    'created_at', pt.created_at,
+                    'created_by', pt.created_by,
+                    'updated_at', pt.updated_at
+                ) AS punishment_type
+            FROM group_punishments gp
+            LEFT JOIN punishment_types pt
+                ON pt.punishment_type_id = gp.punishment_type_id
+            LEFT JOIN (
+                SELECT pr1.*
+                FROM punishment_reactions pr1
+                JOIN group_members gm ON pr1.created_by = gm.user_id
+            ) pr ON pr.punishment_id = gp.punishment_id
+            LEFT JOIN users ON gp.created_by = users.user_id
+            WHERE gp.user_id = $1
+            GROUP BY gp.punishment_id, created_by_name, pt.punishment_type_id
+            ORDER BY gp.created_at DESC
+            """
+            res = await conn.fetch(
+                query,
+                user_id,
+            )
+        
+        return [LeaderboardPunishmentRead(**r) for r in res]

--- a/backend/app/models/punishment.py
+++ b/backend/app/models/punishment.py
@@ -5,6 +5,7 @@ Models for punishment data structures
 from datetime import datetime
 from typing import Optional
 
+from app.models.punishment_type import PunishmentTypeRead
 from pydantic import BaseModel  # pylint: disable=no-name-in-module
 
 from app.models.punishment_reaction import PunishmentReactionRead
@@ -40,6 +41,10 @@ class PunishmentOut(PunishmentCreate):
 class PunishmentRead(PunishmentOut):
     group_id: GroupId
     user_id: UserId
+
+
+class LeaderboardPunishmentRead(PunishmentRead):
+    punishment_type: PunishmentTypeRead
 
 
 class PunishmentStreaks(BaseModel):

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -41,3 +41,10 @@ class LeaderboardPunishmentOut(PunishmentOut):
 class LeaderboardUser(User):
     punishments: list[LeaderboardPunishmentOut]
     total_value: int
+
+  
+class MinifiedLeaderboardUser(User):
+    total_value: int
+    emojis: str
+    amount_punishments: int
+    amount_unique_punishments: int

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "react-router-dom": "^6.15.0",
     "react-simple-oauth2-login": "^0.5.4",
     "react-table": "^7.8.0",
+    "tailwind-scrollbar-hide": "^1.1.7",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@headlessui/react':
     specifier: ^1.7.10
@@ -68,6 +64,9 @@ dependencies:
   react-table:
     specifier: ^7.8.0
     version: 7.8.0(react@18.2.0)
+  tailwind-scrollbar-hide:
+    specifier: ^1.1.7
+    version: 1.1.7
   zod:
     specifier: ^3.22.4
     version: 3.22.4
@@ -3042,6 +3041,10 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /tailwind-scrollbar-hide@1.1.7:
+    resolution: {integrity: sha512-X324n9OtpTmOMqEgDUEA/RgLrNfBF/jwJdctaPZDzB3mppxJk7TLIDmOreEDm1Bq4R9LSPu4Epf8VSdovNU+iA==}
+    dev: false
+
   /tailwindcss@3.2.4(postcss@8.4.31):
     resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
     engines: {node: '>=12.13.0'}
@@ -3297,3 +3300,7 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/frontend/src/components/leaderboardtable/LeaderboardTable.tsx
+++ b/frontend/src/components/leaderboardtable/LeaderboardTable.tsx
@@ -5,7 +5,7 @@ import { QueryObserverResult, RefetchOptions, RefetchQueryFilters } from "@tanst
 
 import { SkeletonTableItem } from "./SkeletonTableItem"
 import { LeaderboardTableItem } from "./LeaderboardTableItem"
-import { useEffect, useRef } from "react"
+import { useState } from "react"
 
 interface LeaderboardTableProps {
   leaderboardUsers?: LeaderboardUser[] | undefined
@@ -13,38 +13,29 @@ interface LeaderboardTableProps {
   dataRefetch: <TPageData>(
     options?: (RefetchOptions & RefetchQueryFilters<TPageData>) | undefined
   ) => Promise<QueryObserverResult<any, unknown>>
-  fetchNextPage: () => Promise<QueryObserverResult<any, unknown>>
 }
 
-export const LeaderboardTable = ({
-  leaderboardUsers,
-  isFetching,
-  dataRefetch,
-  fetchNextPage,
-}: LeaderboardTableProps) => {
-  const ref = useRef<HTMLUListElement>(null)
-
-  useEffect(() => {
-    document.addEventListener("scroll", () => {
-      if (ref.current && !isFetching) {
-        const lastItem = ref.current.firstElementChild?.lastElementChild
-        if (lastItem && lastItem.getBoundingClientRect().top < window.innerHeight) {
-          fetchNextPage().then()
-        }
-      }
-    })
-  }, [])
+export const LeaderboardTable = ({ leaderboardUsers, isFetching, dataRefetch }: LeaderboardTableProps) => {
+  const [currentlyOpen, setCurrentlyOpen] = useState<string | undefined>(undefined)
 
   return (
-    <ul role="list" ref={ref}>
+    <ul role="list">
       <Accordion.Root
         type="single"
         defaultValue="item-1"
         collapsible
+        value={currentlyOpen}
+        onValueChange={(value) => setCurrentlyOpen(value)}
         className="divide-y divide-gray-100 dark:divide-gray-700 bg-white shadow-sm ring-1 ring-gray-900/5 rounded-lg md:rounded-xl"
       >
         {leaderboardUsers?.map((user, i) => (
-          <LeaderboardTableItem key={user.user_id} leaderboardUser={user} dataRefetch={dataRefetch} i={i} />
+          <LeaderboardTableItem
+            key={user.user_id}
+            leaderboardUser={user}
+            isCurrentlyExpanded={currentlyOpen === user.user_id}
+            dataRefetch={dataRefetch}
+            i={i}
+          />
         ))}
 
         {leaderboardUsers && leaderboardUsers.length === 0 && !isFetching && (

--- a/frontend/src/components/leaderboardtable/LeaderboardTableItem.tsx
+++ b/frontend/src/components/leaderboardtable/LeaderboardTableItem.tsx
@@ -23,7 +23,7 @@ export const LeaderboardTableItem = ({ leaderboardUser, isCurrentlyExpanded, dat
   const { data: punishments, isLoading: isLoadingPunishments } = useQuery<LeaderboardPunishment[]>(
     ["leaderboardUserPunishments", leaderboardUser.user_id],
     () => axios.get(getLeaderboardUserPunishmentsUrl(leaderboardUser.user_id)).then((res) => res.data),
-    { enabled: isCurrentlyExpanded }
+    { enabled: isCurrentlyExpanded, staleTime: 1000 * 60 }
   )
 
   const countOfEachEmojiInString = (str: string) => {

--- a/frontend/src/components/menu/Menu.tsx
+++ b/frontend/src/components/menu/Menu.tsx
@@ -11,7 +11,7 @@ export const Menu: FC<MenuProps> = ({ icon, items }) => {
   return (
     <HeadlessUiMenu as="div" className="relative">
       <div>
-        <HeadlessUiMenu.Button className="flex rounded-md bg-white text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:ring-offset-2">
+        <HeadlessUiMenu.Button className="flex rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:ring-offset-2">
           {icon}
         </HeadlessUiMenu.Button>
       </div>

--- a/frontend/src/components/punishment/PunishmentList.tsx
+++ b/frontend/src/components/punishment/PunishmentList.tsx
@@ -4,6 +4,7 @@ import { QueryObserverResult, RefetchOptions, RefetchQueryFilters } from "@tanst
 import { Fragment } from "react"
 import { PunishmentActionBar } from "./PunishmentActionBar"
 import { PunishmentItem } from "./PunishmentItem"
+import { SkeletonPunishmentItem } from "./SkeletonPunishmentItem"
 
 interface PunishmentListProps {
   groupUser?: GroupUser
@@ -11,6 +12,7 @@ interface PunishmentListProps {
   groupId?: string
   punishments: Punishment[]
   punishmentTypes?: Record<string, PunishmentType>
+  isLoadingPunishments?: boolean
   dataRefetch: <TPageData>(
     options?: (RefetchOptions & RefetchQueryFilters<TPageData>) | undefined
   ) => Promise<QueryObserverResult<any, unknown>>
@@ -23,8 +25,13 @@ export const PunishmentList = ({
   groupId,
   punishments,
   punishmentTypes,
+  isLoadingPunishments = false,
   dataRefetch,
 }: PunishmentListProps) => {
+  if (isLoadingPunishments) {
+    return <SkeletonPunishmentItem />
+  }
+
   if (punishments.length === 0) {
     return <Fragment>{groupUser && <PunishmentActionBar label="Ingen straffer" user={groupUser} />}</Fragment>
   }

--- a/frontend/src/components/punishment/SkeletonPunishmentItem.tsx
+++ b/frontend/src/components/punishment/SkeletonPunishmentItem.tsx
@@ -1,0 +1,9 @@
+export const SkeletonPunishmentItem = () => (
+  <div className="flex flex-col gap-2 animate-pulse cursor-pointer justify-between gap-x-6 px-4 py-5 hover:bg-gray-50 sm:px-6">
+    <div className="flex flex-row w-full justify-between gap-x-2">
+      <span className="h-4 w-32 rounded-full bg-slate-300 text-sm font-semibold leading-6 text-gray-900" />
+      <span className="h-4 w-32 rounded-full bg-slate-300 text-sm font-semibold leading-6 text-gray-900" />
+    </div>
+    <span className="h-4 w-48 rounded-full bg-slate-300 text-sm font-semibold leading-6 text-gray-900" />
+  </div>
+)

--- a/frontend/src/helpers/api.ts
+++ b/frontend/src/helpers/api.ts
@@ -580,7 +580,7 @@ export const groupLeaderboardQuery = (
   queryKey: ["groupLeaderboard", groupId],
   queryFn: () => axios.get(getGroupUrl(z.string().parse(groupId))).then((res) => GroupSchema.parse(res.data)),
   enabled: groupId !== undefined,
-  staleTime: 1000,
+  staleTime: 1000 * 60,
 })
 
 export const publicGroupQuery = (groupNameShort?: string) => ({
@@ -590,7 +590,7 @@ export const publicGroupQuery = (groupNameShort?: string) => ({
       .get(BASE_URL + `/groups/public_profiles/${z.string().parse(groupNameShort)}`)
       .then((res) => PublicGroupSchema.parse(res.data)),
   enabled: groupNameShort !== undefined,
-  staleTime: 1000,
+  staleTime: 1000 * 60,
 })
 
 export const userQuery = () => {
@@ -604,7 +604,7 @@ export const userQuery = () => {
       return MeUserSchema.parse(user)
     },
     enabled: auth.isAuthenticated,
-    staleTime: 1000,
+    staleTime: 1000 * 60,
   }
 }
 
@@ -614,7 +614,7 @@ export const committeesQuery = () => ({
     axios.get(GROUP_STATISTICS_URL).then((res: AxiosResponse<GroupStatistics[]>) => {
       return z.array(GroupStatisticsSchema).parse(Array.isArray(res.data) ? res.data : [res.data])
     }),
-  staletime: 1000,
+  staletime: 1000 * 60,
 })
 
 const getLeaderboard = async ({ pageParam = 0 }) =>
@@ -633,5 +633,5 @@ export const leaderboardQuery = (): UseInfiniteQueryOptions<
     const nextPage = lastPage.next ? new URL(lastPage.next).searchParams.get("page") : undefined
     return nextPage ? Number(nextPage) : undefined
   },
-  staleTime: 1000,
+  staleTime: 1000 * 60,
 })

--- a/frontend/src/helpers/api.ts
+++ b/frontend/src/helpers/api.ts
@@ -35,6 +35,8 @@ const LEADERBOARD_URL = BASE_URL + "/users/leaderboard"
 
 const getLeaderboardUrl = (page: number) => `${LEADERBOARD_URL}?page=${page}`
 
+export const getLeaderboardUserPunishmentsUrl = (userId: string) => `${LEADERBOARD_URL}/punishments/${userId}`
+
 const GROUPS_URL = BASE_URL + "/groups/me"
 
 const ME_URL = BASE_URL + "/users/me"

--- a/frontend/src/helpers/types.ts
+++ b/frontend/src/helpers/types.ts
@@ -93,7 +93,9 @@ export type LeaderboardPunishment = z.infer<typeof LeaderboardPunishmentSchema>
 
 export const LeaderboardUserSchema = UserSchema.extend({
   total_value: z.number(),
-  punishments: z.array(LeaderboardPunishmentSchema),
+  emojis: z.string(),
+  amount_punishments: z.number(),
+  amount_unique_punishments: z.number(),
 })
 export type LeaderboardUser = z.infer<typeof LeaderboardUserSchema>
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -67,20 +67,45 @@
   }
 }
 
-/* For Webkit-based browsers (Chrome, Safari and Opera) */
-.scrollbar-hide::-webkit-scrollbar {
+/* .scrollbar-hide::-webkit-scrollbar {
   display: none;
 }
 
-/* For IE, Edge and Firefox */
 .scrollbar-hide {
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
-}
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+} */
+
+
 
 .with-horizontal-scroll-shadow {
   background-position: left center, right center, left center, right center;
   background-repeat: no-repeat;
   background-size: 20px 100%, 20px 100%, 10px 100%, 10px 100%;
   background-attachment: local, local, scroll, scroll;
+}
+
+.lowkey-scrollbar {
+  width: 100%;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.lowkey-scrollbar::-webkit-scrollbar {
+  display: block;
+  width: 0.4rem;
+  height: 0.4rem;
+}
+
+.lowkey-scrollbar::-webkit-scrollbar-thumb {
+  background-color: #888;
+  border-radius: 5px;
+}
+
+.lowkey-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: #666;
+}
+
+.lowkey-scrollbar::-webkit-scrollbar-track {
+  background-color: transparent;
 }

--- a/frontend/src/pages/wallOfShame/WallOfShame.tsx
+++ b/frontend/src/pages/wallOfShame/WallOfShame.tsx
@@ -1,7 +1,7 @@
-import { useAuth } from "react-oidc-context"
 import { LeaderboardTable } from "../../components/leaderboardtable"
 import { useInfiniteQuery } from "@tanstack/react-query"
 import { leaderboardQuery } from "../../helpers/api"
+import { Button } from "../../components/button/Button"
 
 export const WallOfShame = () => {
   const { isFetching, data, refetch, fetchNextPage } = useInfiniteQuery(leaderboardQuery())
@@ -15,8 +15,10 @@ export const WallOfShame = () => {
         leaderboardUsers={leaderboardUsers}
         isFetching={isFetching}
         dataRefetch={refetch}
-        fetchNextPage={fetchNextPage}
       />
+      <Button variant="OUTLINE" onClick={() => fetchNextPage().then()} className="mx-auto mt-4">
+        Last inn mer
+      </Button>
     </section>
   )
 }

--- a/frontend/src/views/groups/GroupView.tsx
+++ b/frontend/src/views/groups/GroupView.tsx
@@ -32,6 +32,7 @@ import { useGivePunishmentModal } from "../../helpers/context/modal/givePunishme
 import { GroupUserTable } from "../../components/groupusertable"
 import { useMutation, useQuery } from "@tanstack/react-query"
 import { signinAndReturn } from "../../helpers/auth"
+import { AdditionalGroupNavItem } from "./tabnav/AdditionalGroupNavItem"
 
 export const GroupView = () => {
   const { currentUser, setCurrentUser } = useCurrentUser()
@@ -194,44 +195,47 @@ export const GroupView = () => {
         <section className="md:grid gap-x-6 md:grid-cols-[20rem_minmax(26rem,_1fr)] max-w-screen-xl w-[90%] mx-auto">
           <div className="md:mt-[5.5rem] hidden md:block">{sidebarElement}</div>
           <div className="mt-8 md:mt-12 w-full mx-auto md:mx-0">
-            <div className="flex flex-row justify-between items-end w-full mb-px">
+            <div className="flex flex-row justify-between items-center w-full gap-x-1 mb-px">
               <TabNav
                 selectedGroup={selectedGroup}
                 setSelectedGroup={(group: Group) => group && navigate(`/gruppe/${group.name_short.toLowerCase()}`)}
                 groups={user ? user.groups : undefined}
               />
-              <Popover className="relative mb-1 mr-2 block md:hidden">
-                {({ open }) => (
-                  <>
-                    <Popover.Button
-                      className={`
+              <div className="flex flex-row items-center px-2">
+                <AdditionalGroupNavItem />
+                <Popover className="relative mb-1 mr-2 block md:hidden">
+                  {({ open }) => (
+                    <>
+                      <Popover.Button
+                        className={`
                   ${open ? "text-white" : "text-white/90"}
                   group z-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/75`}
-                    >
-                      <Cog6ToothIcon
-                        className={`${
-                          open ? "text-gray-900 dark:text-gray-300" : "text-gray-900/70 dark:text-gray-300/70"
-                        }
-                    h-5 w-5 md:h-6 md:w-6 transition duration-150 ease-in-out group-hover:text-gray-900/80 dark:group-hover:text-gray-300/80`}
-                        aria-hidden="true"
-                      />
-                    </Popover.Button>
-                    <Transition
-                      as={Fragment}
-                      enter="transition ease-out duration-200"
-                      enterFrom="opacity-0 translate-y-1"
-                      enterTo="opacity-100 translate-y-0"
-                      leave="transition ease-in duration-150"
-                      leaveFrom="opacity-100 translate-y-0"
-                      leaveTo="opacity-0 translate-y-1"
-                    >
-                      <Popover.Panel className="absolute z-10 mt-3 -right-10 shadow-2xl rounded-xl w-screen max-w-sm transform sm:px-0 lg:max-w-3xl">
-                        {sidebarElement}
-                      </Popover.Panel>
-                    </Transition>
-                  </>
-                )}
-              </Popover>
+                      >
+                        <Cog6ToothIcon
+                          className={`${
+                            open ? "text-gray-900 dark:text-gray-300" : "text-gray-900/70 dark:text-gray-300/70"
+                          }
+                    h-6 w-6 transition duration-150 ease-in-out group-hover:text-gray-900/80 dark:group-hover:text-gray-300/80`}
+                          aria-hidden="true"
+                        />
+                      </Popover.Button>
+                      <Transition
+                        as={Fragment}
+                        enter="transition ease-out duration-200"
+                        enterFrom="opacity-0 translate-y-1"
+                        enterTo="opacity-100 translate-y-0"
+                        leave="transition ease-in duration-150"
+                        leaveFrom="opacity-100 translate-y-0"
+                        leaveTo="opacity-0 translate-y-1"
+                      >
+                        <Popover.Panel className="absolute z-10 mt-3 -right-10 shadow-2xl rounded-xl w-screen max-w-sm transform sm:px-0 lg:max-w-3xl">
+                          {sidebarElement}
+                        </Popover.Panel>
+                      </Transition>
+                    </>
+                  )}
+                </Popover>
+              </div>
             </div>
             <GroupUserTable
               groupData={data}

--- a/frontend/src/views/groups/tabnav/AdditionalGroupNavItem.tsx
+++ b/frontend/src/views/groups/tabnav/AdditionalGroupNavItem.tsx
@@ -33,8 +33,8 @@ export const AdditionalGroupNavItem = () => {
     <div className="-ml-2 -mt-2">
       <Menu
         icon={
-          <span className="text-gray-700 opacity-70 hover:opacity-90">
-            <PlusIcon className="h-5 w-5 md:h-[1.6rem] md:w-[1.6rem]" />
+          <span className="text-gray-900/70 dark:text-gray-300/70 hover:opacity-90">
+            <PlusIcon className="h-6 w-6" />
           </span>
         }
         items={listItems}

--- a/frontend/src/views/groups/tabnav/TabNav.tsx
+++ b/frontend/src/views/groups/tabnav/TabNav.tsx
@@ -33,7 +33,7 @@ export const TabNav = ({ selectedGroup, setSelectedGroup, groups }: TabNavProps)
                 <>
                   <div
                     className={classNames(
-                      "flex flex-row gap-x-3 md:gap-x-8 items-center overflow-x-auto scrollbar-hide",
+                      "flex flex-row gap-x-3 md:gap-x-4 items-center overflow-x-auto lowkey-scrollbar [@media(max-width:767px)]:scrollbar-hide",
                       "with-horizontal-scroll-shadow"
                     )}
                   >
@@ -48,7 +48,7 @@ export const TabNav = ({ selectedGroup, setSelectedGroup, groups }: TabNavProps)
                       />
                     ))}
                   </div>
-                  <AdditionalGroupNavItem />
+                  {/* <AdditionalGroupNavItem /> */}
                 </>
               ) : (
                 <SkeletonTabNavItem />

--- a/frontend/src/views/groups/tabnav/TabNavItem.tsx
+++ b/frontend/src/views/groups/tabnav/TabNavItem.tsx
@@ -31,17 +31,18 @@ export const TabNavItem = ({ group, selectedGroup, ...props }: TabNavItemProps) 
       aria-current={group.group_id ? "page" : undefined}
       {...props}
     >
-      <GroupIcon
-        className={classNames(
-          group.name_short === selectedGroup?.name_short
-            ? "text-gray-900 dark:text-gray-100"
-            : "text-gray-500 dark:text-gray-500 group-hover:text-gray-900 dark:group-hover:text-gray-100",
-          "-mt-1 h-6 w-6 md:h-7 md:w-7",
-          group.image ? "grayscale dark:invert" : ""
-        )}
-        aria-hidden="true"
-      />
-      <span>{group.name_short}</span>
+      <div className="-mt-1 h-6 w-6 md:h-7 md:w-7">
+        <GroupIcon
+          className={classNames(
+            group.name_short === selectedGroup?.name_short
+              ? "text-gray-900 dark:text-gray-100"
+              : "text-gray-500 dark:text-gray-500 group-hover:text-gray-900 dark:group-hover:text-gray-100",
+            group.image !== "NoImage" && group.image ? "grayscale dark:invert" : ""
+          )}
+          aria-hidden="true"
+        />
+      </div>
+      <span className="whitespace-nowrap">{group.name_short}</span>
     </a>
   )
 }

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -48,5 +48,5 @@ module.exports = {
       },
     },
   },
-  plugins: [require("@tailwindcss/forms")],
+  plugins: [require("@tailwindcss/forms"), require("tailwind-scrollbar-hide")],
 }


### PR DESCRIPTION
Wall of shame now actually loads fast. It does this by having two separate api endpoints; one for requesting basic data like how many punishments everyone has, and one for actually loading a users punishments whenever you click on them.

Also snuck in some changes related to the groups tabbar. Nobody else will notice them unless they are in many groups, but for me and Frederik these changes are equivalent to saving a dying child from a highrise building.
