### PR TITLE
Add soft purge from group on ow group removal

### DIFF
--- a/backend/app/db/group_members.py
+++ b/backend/app/db/group_members.py
@@ -114,11 +114,11 @@ class GroupMembers:
     ) -> list[dict[str, Union[GroupId, UserId]]]:
         async with MaybeAcquire(conn, self.db.pool) as conn:
             query = """UPDATE group_members
-                    SET active = m.active
+                    SET active = m.active, ow_group_user_id = m.ow_group_user_id
                     FROM
                         unnest($1::group_members[]) as m
                     WHERE
-                        group_members.ow_group_user_id = m.ow_group_user_id
+                        group_members.group_id = m.group_id AND group_members.user_id = m.user_id
                     RETURNING m.group_id, m.user_id;
                     """
 

--- a/backend/app/db/users.py
+++ b/backend/app/db/users.py
@@ -342,12 +342,12 @@ class Users:
             if not is_ow_user_id:
                 query = """SELECT groups.* FROM groups
                         INNER JOIN group_members ON groups.group_id = group_members.group_id
-                        WHERE group_members.user_id = $1"""
+                        WHERE group_members.user_id = $1 AND group_members.active = TRUE"""
             else:
                 query = """SELECT groups.* FROM groups
                         INNER JOIN group_members ON groups.group_id = group_members.group_id
                         INNER JOIN users ON users.user_id = group_members.user_id
-                        WHERE users.ow_user_id = $1"""
+                        WHERE users.ow_user_id = $1 AND group_members.active = TRUE"""
 
             result = await conn.fetch(query, user_id)
             return [Group(**row) for row in result]

--- a/backend/app/http.py
+++ b/backend/app/http.py
@@ -142,16 +142,26 @@ class HTTPClient:
             data = await response.json()
             return data["results"]
 
-    async def get_ow_groups_by_user_id(self, user_id: int) -> Any:
+    async def get_ow_groups_by_user_id(
+        self, user_id: int, page: Optional[int] = 1
+    ) -> Any:
         params = {
             "members__user": user_id,
+            "page": page,
         }
 
         async with self._session.get(
             f"{BASE_OLD_ONLINE}/api/v1/group/online-groups/",
             params=params,
         ) as response:
-            return await response.json()  # TODO?: Implement pagination?
+            data = await response.json()
+            results = data["results"]
+
+            if data["next"] is not None:
+                next_page_data = await self.get_ow_groups_by_user_id(user_id, page + 1)
+                results.extend(next_page_data)
+            
+            return results
 
     async def get_ow_group_users(self, group_id: int) -> Any:
         async with self._session.get(

--- a/backend/app/sync.py
+++ b/backend/app/sync.py
@@ -92,7 +92,6 @@ class OWSync:
                 if g["id"] not in IGNORE_OW_GROUPS
                 and g["group_type"] in ("committee", "node_committee")
             ]
-            # print(json.dumps(filtered_groups_data, indent=4))
             ow_group_ids = set(g["id"] for g in filtered_groups_data)
             group_ids_not_in_ow_group_anymore = [
                 g.group_id

--- a/frontend/src/components/groupusertable/GroupUserTable.tsx
+++ b/frontend/src/components/groupusertable/GroupUserTable.tsx
@@ -41,6 +41,7 @@ export const GroupUserTable = ({
         className="divide-y divide-gray-100 dark:divide-gray-700 bg-white shadow-sm ring-1 ring-gray-900/5 rounded-lg md:rounded-xl"
       >
         {groupData?.members
+          .filter((user) => user.active)
           .filter(filterUsers)
           .sort(getSortGroupUsersFunc(groupData?.punishment_types, sortingAlternative))
           .map((user) => (


### PR DESCRIPTION
Previously, when you were removed from an OW group (done on dashboard), the sync module would remove you from the group in vengeful's database along with all your punishments. This obviously would be bad for wall of shame, as being removed from lets say a temporary commitment like Velkom or HS would mean you were set back on the wall of shame. Therefore, this PR makes it so that a user is never truly removed from an OW group, only soft purged by setting you as inactive. To the user it seems like they are removed, but in reality if they are readded to the group, the punishments persists.