### PR TITLE
Fix: Docs and make vinstraff run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,82 +13,167 @@ The old and outdated version can be found here: [RedWine](https://online.ntnu.no
 
 ## Project Status
 
-The project is is finished🎉
+The project is finished :tada:
+
 It is currently being maintained by [Dotkom from the Online student association](https://online.ntnu.no/).
 
 The link to the page is: [Vengeful Vineyard](https://vinstraff.no/)
 
-## Frontend
+## Tech Stack
 
-### Built with
-
-- [Typescript](https://www.typescriptlang.org/)
+### Frontend
+- [TypeScript](https://www.typescriptlang.org/)
 - [React](https://reactjs.org/)
-- [Tailwind](https://tailwindcss.com/)
+- [Tailwind CSS](https://tailwindcss.com/)
 - [Vite](https://vitejs.dev/)
 
-### Doppler
+### Backend
+- [FastAPI](https://fastapi.tiangolo.com)
+- PostgreSQL
 
-We use [Doppler](https://docs.doppler.com) to manage secrets. After installation, set up using:
+---
 
-- `doppler login`
-- `doppler setup`
-  - (select vengeful-vineyard, dev)
+## Getting Started (Local Development)
 
-### Installation and running locally
+> **Note:** Running locally requires all three services: **Online Web (monoweb)**, **Backend**, and **Frontend**. The frontend authenticates users through Online Web, and requires the backend API to function.
 
-- `cd frontend`
-- `pnpm i`
-- `doppler run pnpm dev`
+### Prerequisites
 
-## Backend
+Make sure you have the following installed:
+- [Docker](https://www.docker.com/) and Docker Compose
+- [Node.js](https://nodejs.org/) and [pnpm](https://pnpm.io/)
+- [Doppler CLI](https://docs.doppler.com/docs/install-cli)
 
-Created with [FastAPI](https://fastapi.tiangolo.com) and PostgreSQL.
+### Step 1: Set up Doppler
 
-#### (Recommended) Running locally with docker compose
+We use [Doppler](https://docs.doppler.com) to manage secrets.
 
-- Make sure you have docker and docker compose installed.
-- `cd backend`
-- Start server with: `make dev`
-- Go to: http://localhost:8000/docs for Swagger docs
+```bash
+doppler login
+doppler setup
+# Select: vengeful-vineyard, dev
+```
+
+### Step 2: Set up Online Web (Authentication)
+
+The frontend uses [Online Web (monoweb)](https://github.com/dotkom/monoweb) for user authentication. You need to run it locally.
+
+1. Clone and set up monoweb by following the instructions at: https://github.com/dotkom/monoweb
+
+2. To get started quickly with test data, run:
+   ```bash
+   pnpm migrate:dev-with-fixtures
+   ```
+
+3. **Important:** After monoweb is running, go to the dashboard and add yourself as a member of **Dotkom**. This gives you the necessary permissions to see all features in the Vengeful Vineyard frontend.
+
+### Step 3: Start the Backend
+
+The backend must be running before starting the frontend.
+
+```bash
+cd backend
+make dev
+```
+
+This starts the FastAPI server with PostgreSQL using Docker Compose.
+
+- API docs available at: http://localhost:8000/docs
+
+#### Syncing Production Data (Optional)
+
+If you have Doppler access to production, you can sync the production database to your local environment:
+
+```bash
+make db-sync
+```
+
+### Step 4: Start the Frontend
+
+```bash
+cd frontend
+pnpm install
+doppler run pnpm dev
+```
+
+The frontend will be available at: http://localhost:5173 (or similar)
+
+---
 
 ## Contributing
 
 Please take a look at our issues if you want to contribute to this project. Pull requests are welcome!
 
-Before contributing, make sure to install pre-commit hooks with `pre-commit install`.
+Before contributing, make sure to install pre-commit hooks:
 
-If you don't have `pre-commit` installed, you can install it with `pip install pre-commit` or `brew install pre-commit`
+```bash
+# Install pre-commit if you don't have it
+pip install pre-commit
+# or
+brew install pre-commit
 
-## Deploying changes
+# Install the hooks
+pre-commit install
+```
 
-Do deploy changes to the aws. You will need to have the AWS CLI installed and set up.
-First ask dotkom for credentials so that they can create a IAM user for you. Then do the following steps:
+---
 
-- Install AWS CLI
-- Then run `aws configure' in the terminal
-  - Optional: Set up a new profile for the project
-  - Instead run `aws configure --profile dotkom`
+## Deployment
 
-### Backend Deployment Instructions
+To deploy changes to AWS, you need the AWS CLI installed and configured. Ask Dotkom for credentials to create an IAM user for you.
 
-- `cd backend`
-- `make deploy-prod`
-  - Optionally if you are having profiles set up, you can run `make deploy-prod PROFILE=dotkom`
-- Go to the Terraform monorepo and get into correct stage, `staging/vengeful-vineyard` or `prod/vengeful-vineyard` directory
-  - Run `terraform init` or optionally `AWS_PROFILE=dotkom terraform init`
-  - Then apply the changes with `doppler run terraform apply` or optionally `AWS_PROFILE=dotkom doppler run terraform apply`
+### AWS Setup
 
-### Frontend Deployment Instructions
-Note: You will need to have the Doppler CLI installed and set up.
+```bash
+# Install AWS CLI, then configure
+aws configure --profile dotkom
+```
 
-- `doppler login`
-- `doppler setup` - (select vengeful-vineyard, dev)
-- `cd frontend`
-- `npm run deploy:prod`
-  - Optionallly if you are having profiles set up, you can run `npm run deploy:prod -- --profile=dotkom`
+### Backend Deployment
 
-### Debugging Tips
+```bash
+cd backend
+make deploy-prod
+# Or with profile:
+make deploy-prod PROFILE=dotkom
+```
 
-- Delete `/backend/postgres-data`
-- `docker-compose up --build`
+Then go to the Terraform monorepo (`staging/vengeful-vineyard` or `prod/vengeful-vineyard` directory):
+
+```bash
+terraform init
+# Or: AWS_PROFILE=dotkom terraform init
+
+doppler run terraform apply
+# Or: AWS_PROFILE=dotkom doppler run terraform apply
+```
+
+### Frontend Deployment
+
+```bash
+doppler login
+doppler setup  # Select vengeful-vineyard, dev
+
+cd frontend
+npm run deploy:prod
+# Or with profile:
+npm run deploy:prod -- --profile=dotkom
+```
+
+---
+
+## Troubleshooting
+
+### Database Issues
+
+If you encounter database issues, try resetting the local database:
+
+```bash
+cd backend
+rm -rf postgres-data
+docker-compose up --build
+```
+
+### Authentication Issues
+
+Make sure Online Web (monoweb) is running on the expected port and that you're logged in there first before accessing Vengeful Vineyard.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --no-cache gcc libffi-dev musl-dev postgresql-dev
 RUN pip3 install poetry virtualenv
 RUN poetry config virtualenvs.create false
 RUN poetry install -n --no-ansi --no-root
+RUN pip3 install "packaging>=24.0"
 
 COPY . /app
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -4,7 +4,7 @@ export SHELLOPTS:=$(if $(SHELLOPTS),$(SHELLOPTS):)pipefail:errexit
 PROFILE ?= default
 
 .ONESHELL:
-.PHONY: prod dev dev-memory test testv testvv mypy pylint clean help hooks docs
+.PHONY: prod dev dev-memory test testv testvv mypy pylint clean help hooks docs db-sync
 
 prod: .prod-reqs
 	VENGEFUL_DATABASE="vengeful_vineyard.db" poetry run uvicorn app.api.init_api:asgi_app --host 0.0.0.0
@@ -73,6 +73,22 @@ deploy-prod: docker-build docker-login docker-push-prod
 
 deploy-staging: docker-build docker-login docker-push-staging
 
+db-sync:
+	@echo "Syncing production database to local..."
+	@echo "Step 1: Dumping production database..."
+	doppler run --config prd -- sh -c 'PGPASSWORD="$$POSTGRES_PASSWORD" pg_dump -h "$$POSTGRES_HOST" -p "$$POSTGRES_PORT" -U "$$POSTGRES_USER" -d "$$POSTGRES_DB" --no-owner --no-acl' > /tmp/prod_dump.sql
+	@echo "Step 2: Stopping app container..."
+	docker compose stop app
+	@echo "Step 3: Dropping and recreating local database..."
+	docker compose exec db psql -U postgres -c "DROP DATABASE IF EXISTS dev;"
+	docker compose exec db psql -U postgres -c "CREATE DATABASE dev;"
+	@echo "Step 4: Loading production data into local database..."
+	docker compose exec -T db psql -U postgres -d dev < /tmp/prod_dump.sql
+	@echo "Step 5: Restarting containers..."
+	docker compose up -d
+	@echo "Done! Local database now contains production data."
+	rm /tmp/prod_dump.sql
+
 help:
 	@echo "Makefile commands:"
 	@echo "help:         Show this help."
@@ -87,8 +103,9 @@ help:
 	@echo "pylint:       Python linter to check for common mistakes"
 	@echo "mypy:         Typecheck Python code"
 	@echo "hooks:        Run all commit hooks"
-	@echo "docker-build: Build docker image for AWS Lambda
-	@echo "docker-login: Log in to Amazon ECR
-	@echo "docker-push-: Push the docker image to the specified environment (dev,stg,prd)
+	@echo "docker-build: Build docker image for AWS Lambda"
+	@echo "docker-login: Log in to Amazon ECR"
+	@echo "docker-push-: Push the docker image to the specified environment (dev,stg,prd)"
 	@echo ""
-	@echo "clean:   Clean up Python environment"
+	@echo "db-sync:      Sync production database to local (requires Doppler access)"
+	@echo "clean:        Clean up Python environment"


### PR DESCRIPTION
## Summary

- **Fix user login when ow_user_id format changes** - Handle the case where OW returns different user ID formats (e.g., `auth0|...` vs `oauth2|FEIDE|...`) for the same user. Previously this caused a 500 error due to email uniqueness constraint violation.

- **Add `make db-sync` command** - New Makefile target to sync production database to local development environment. Requires Doppler access to production.

- **Rewrite README for newcomers** - Complete overhaul of documentation with clear step-by-step instructions for running locally, including:
  - Prerequisites
  - Doppler setup
  - Online Web (monoweb) setup for authentication
  - Backend and frontend startup order
  - Troubleshooting tips

## Changes

### `backend/app/db/users.py`
- Handle email unique constraint violation in `upsert()` by updating existing user's `ow_user_id`
- Also update `ow_group_user_id` in `group_members` to preserve group memberships

### `backend/Makefile`
- Add `db-sync` target to sync production database to local

### `README.md`
- Restructured with clear "Getting Started" section
- Added note that all three services (monoweb, backend, frontend) are required
- Added Online Web setup instructions with link to monoweb repo
- Documented the new `db-sync` command

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] I have run lints